### PR TITLE
v0.1.1 (2025-04-17)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # CHANGELOG
 
+## v0.1.1 (April 2025)
+
+### Fixed:
+
+- Allow for custom output folder name for results
+- Allow for sample to have assembly but no species ID from sylph
+- Broken run name in report header
+- Parsing input string of concatenate rules for typing rules
+- Removed leftover parameters and outputs that were no longer used
+
+### Changed:
+
+- Memory requirements for kraken2 changed from 16 Gb in rule to 10 Gb
+- Parsing of kraken2 species ID when sylph is missing ID in report
+
 ## v0.1.0 (March 2025)
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ By default, several resource-intensive steps have a minimum resource usage alloc
 | Tool | CPUs | Memory |
 | :--- | :--- | :--- |
 | `sylph` | 8 | 14 Gb |
-| `kraken2` | 8 | 8 Gb |
+| `kraken2` | 8 | 10 Gb |
 | `CheckM2` | 8 | 12 Gb |
 | `Flye` | 8 | 2 Gb |
  

--- a/config/README.md
+++ b/config/README.md
@@ -59,8 +59,6 @@ To adjust specific parameters used by tools in the workflow, edit the fields in 
     - percent identity ` --pid-threshold 90`
 - KMERRESISTANCE
     - ONT long-read preset for KMA `-ont`
-- QUAST (QUAST assembly quality metrics):
-    - minimum size of contig considered ` --min-contig 0`
 - STAPH_AUREUS_TYPING (*Staphylococcus aureus* toxin typing via VFDB and ABRicate)
 - STREP_PYOGENES_TYPING (*Streptococcus pyogenes* *emm* typing via emmtyper)
     - verbose `--output format verbose`

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -19,7 +19,6 @@ PARAMS:
     COVERM: "mean length --min-covered-fraction 0"
     STARAMR: "--pid-threshold 90"
     KMERRESISTANCE: "-ont"
-    QUAST: "--min-contig 0"
     STAPH_AUREUS_TYPING: ""
     STREP_PYOGENES_TYPING: "--output-format verbose"
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -139,6 +139,7 @@ rule generate_report:
         cgekey=os.path.join("resources", "cge_key_20240612_phenotypes.txt"),
         vfdb=os.path.join(output_dir, "typing_staph_aureus_toxins.tsv"),
         emm=os.path.join(output_dir, "typing_strep_pyo_emm.tsv"),
+        fungi=os.path.join(output_dir, "spp_fungi_samples.tsv"),
         checkm=os.path.join(output_dir, "qc_assembly_checkm2.tsv"),
     output:
         output_report,
@@ -181,6 +182,7 @@ rule generate_report:
                 checkm="{input.checkm}", \
                 vfdb="{input.vfdb}", \
                 emm="{input.emm}", \
+                fungi="{input.fungi}", \
                 clsi="{input.clsi}"),
             output_file = "{output}")' ) &> {log}
         mv workflow/scripts/{output} {output}

--- a/workflow/rules/amr.smk
+++ b/workflow/rules/amr.smk
@@ -22,6 +22,7 @@ rule amr_kmerresistance:
         arg_db=config["DATABASES"]["KMERRESISTANCE_DB_ARG"],
         spp_db=config["DATABASES"]["KMERRESISTANCE_DB_SPP"],
         extra=config["PARAMS"]["KMERRESISTANCE"],
+        folder=config['OUTPUT_FOLDER_NAME']
     threads: 1
     log:
         os.path.join(
@@ -35,7 +36,7 @@ rule amr_kmerresistance:
         )
     shell:
         """
-        (kmerresistance -i {input.reads} -o results/amr_kmerresistance/{wildcards.sample} -t_db {params.arg_db} -s_db {params.spp_db} {params.extra}) &> {log}
+        (kmerresistance -i {input.reads} -o {params.folder}/amr_kmerresistance/{wildcards.sample} -t_db {params.arg_db} -s_db {params.spp_db} {params.extra}) &> {log}
         """
 
 
@@ -49,11 +50,13 @@ rule amr_kmerresistance_concatenate:
     output:
         os.path.join(output_dir, "amr_kmerresistance_summary.tsv"),
     threads: 1
+    params:
+        folder=config['OUTPUT_FOLDER_NAME']
     log:
         os.path.join(output_dir_logs, "amr_kmerresistance", "concatenate.out"),
     shell:
         """
-        grep -H "" {input} | sed 's#.*Score.*##g;s#.KmerRes:#\t#g;s#results/amr_kmerresistance/##g;s#*NC_007795*$##g' | awk 'NF' | sort > {output}
+        grep -H "" {input} | sed 's#.*Score.*##g;s#.KmerRes:#\t#g;s#{params.folder}/amr_kmerresistance/##g;s#*NC_007795*$##g' | awk 'NF' | sort > {output}
         """
 
 
@@ -73,6 +76,7 @@ rule amr_staramr:  # settings: 90% identity over 60% coverage
     params:
         extra=config["PARAMS"]["STARAMR"],
         organism=get_pointfinder_organism,
+        folder=config['OUTPUT_FOLDER_NAME']
     log:
         os.path.join(output_dir_logs, "amr_staramr", "{sample}_staramr.out"),
     benchmark:
@@ -82,13 +86,13 @@ rule amr_staramr:  # settings: 90% identity over 60% coverage
     shell:
         """
         # remove output folders if they exist, cannot force overwrite
-        if [ -d results/amr_staramr/{wildcards.sample}/ ]; then
-            rm -r results/amr_staramr/{wildcards.sample}/
+        if [ -d {params.folder}/amr_staramr/{wildcards.sample}/ ]; then
+            rm -r {params.folder}/amr_staramr/{wildcards.sample}/
         fi
         
-        (staramr search -o results/amr_staramr/{wildcards.sample}/ {params.organism} {params.extra} {input}) &> {log}
+        (staramr search -o {params.folder}/amr_staramr/{wildcards.sample}/ {params.organism} {params.extra} {input}) &> {log}
 
-        mv results/amr_staramr/{wildcards.sample}/detailed_summary.tsv {output.report}
+        mv {params.folder}/amr_staramr/{wildcards.sample}/detailed_summary.tsv {output.report}
         """
 
 
@@ -101,11 +105,12 @@ rule amr_staramr_concatenate:
     threads: 1
     params:
         gather_files=lambda wildcards, input: input.gather_files,
+        folder=config['OUTPUT_FOLDER_NAME']
     log:
         os.path.join(output_dir_logs, "amr_staramr", "concatenate.out"),
     shell:
         """
-        if [[ -d results/amr_staramr ]]; then
+        if [[ -d {params.folder}/amr_staramr ]]; then
             cat {params.gather_files} | sed 's#^Isolate.*##g' | awk 'NF' > {output}
         else 
             (echo ""

--- a/workflow/rules/amr.smk
+++ b/workflow/rules/amr.smk
@@ -22,7 +22,7 @@ rule amr_kmerresistance:
         arg_db=config["DATABASES"]["KMERRESISTANCE_DB_ARG"],
         spp_db=config["DATABASES"]["KMERRESISTANCE_DB_SPP"],
         extra=config["PARAMS"]["KMERRESISTANCE"],
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config["OUTPUT_FOLDER_NAME"],
     threads: 1
     log:
         os.path.join(
@@ -51,7 +51,7 @@ rule amr_kmerresistance_concatenate:
         os.path.join(output_dir, "amr_kmerresistance_summary.tsv"),
     threads: 1
     params:
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config["OUTPUT_FOLDER_NAME"],
     log:
         os.path.join(output_dir_logs, "amr_kmerresistance", "concatenate.out"),
     shell:
@@ -76,7 +76,7 @@ rule amr_staramr:  # settings: 90% identity over 60% coverage
     params:
         extra=config["PARAMS"]["STARAMR"],
         organism=get_pointfinder_organism,
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config["OUTPUT_FOLDER_NAME"],
     log:
         os.path.join(output_dir_logs, "amr_staramr", "{sample}_staramr.out"),
     benchmark:
@@ -105,7 +105,7 @@ rule amr_staramr_concatenate:
     threads: 1
     params:
         gather_files=lambda wildcards, input: input.gather_files,
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config["OUTPUT_FOLDER_NAME"],
     log:
         os.path.join(output_dir_logs, "amr_staramr", "concatenate.out"),
     shell:

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -14,6 +14,7 @@ checkpoint assembly_flye:
         assembly=os.path.join(output_dir, "assembly_flye", "{sample}_flye.fasta"),
     params:
         extra=config["PARAMS"]["FLYE"],
+        folder=config['OUTPUT_FOLDER_NAME']
     threads: 8
     resources:
         mem_mb=2000,
@@ -25,12 +26,12 @@ checkpoint assembly_flye:
         )
     shell:
         """
-        (flye {params.extra} {input.reads} --out-dir results/assembly_flye/{wildcards.sample} --threads {threads}) &> {log} || true
+        (flye {params.extra} {input.reads} --out-dir {params.folder}/assembly_flye/{wildcards.sample} --threads {threads}) &> {log} || true
 
         # copy assembly if it exists
-        if [ -f results/assembly_flye/{wildcards.sample}/assembly.fasta ]; then
-            cp results/assembly_flye/{wildcards.sample}/assembly.fasta results/assembly_flye/{wildcards.sample}/{wildcards.sample}_flye.fasta
-            cp results/assembly_flye/{wildcards.sample}/assembly.fasta {output.assembly}
+        if [ -f {params.folder}/assembly_flye/{wildcards.sample}/assembly.fasta ]; then
+            cp {params.folder}/assembly_flye/{wildcards.sample}/assembly.fasta {params.folder}/assembly_flye/{wildcards.sample}/{wildcards.sample}_flye.fasta
+            cp {params.folder}/assembly_flye/{wildcards.sample}/assembly.fasta {output.assembly}
         
         # if it doesn't exist, make a fake output assembly so this rule completes
         else

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -14,7 +14,7 @@ checkpoint assembly_flye:
         assembly=os.path.join(output_dir, "assembly_flye", "{sample}_flye.fasta"),
     params:
         extra=config["PARAMS"]["FLYE"],
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config["OUTPUT_FOLDER_NAME"],
     threads: 8
     resources:
         mem_mb=2000,

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -78,7 +78,7 @@ rule qc_remove_host_stats:
     output:
         os.path.join(output_dir, "qc_host_removed.tsv"),
     params:
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config["OUTPUT_FOLDER_NAME"],
     log:
         os.path.join(output_dir_logs, "qc_remove_host_stats", "remove_host_stats.out"),
     shell:
@@ -174,7 +174,7 @@ rule qc_failed_assemblies:
         os.path.join(output_dir, "qc_failed_assemblies.txt"),
     threads: 1
     params:
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config["OUTPUT_FOLDER_NAME"],
     log:
         os.path.join(output_dir_logs, "assembly_failed", "failed_assembly.out"),
     shell:
@@ -204,7 +204,7 @@ rule qc_checkm2:
         gather_files=lambda wildcards, input: input.gather_files,
         db=config["DATABASES"]["CHECKM2_DB"],
         extra=config["PARAMS"]["CHECKM2"],
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config["OUTPUT_FOLDER_NAME"],
     resources:
         mem_mb=10000,
     log:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -77,11 +77,13 @@ rule qc_remove_host_stats:
         ),
     output:
         os.path.join(output_dir, "qc_host_removed.tsv"),
+    params:
+        folder=config['OUTPUT_FOLDER_NAME']
     log:
         os.path.join(output_dir_logs, "qc_remove_host_stats", "remove_host_stats.out"),
     shell:
         """
-        (grep -H "sequences classified (" {input.logs} | tr -s '[:blank:]' | sed "s#results/logs/qc_nohuman/##g;s#_nohuman\\.out##g;s#: .*(#\t#g;s#%)##g" | sort | sed '1i sample\treads_removed_percent' > {output}) &> {log}
+        (grep -H "sequences classified (" {input.logs} | tr -s '[:blank:]' | sed "s#{params.folder}/logs/qc_nohuman/##g;s#_nohuman\\.out##g;s#: .*(#\t#g;s#%)##g" | sort | sed '1i sample\treads_removed_percent' > {output}) &> {log}
         """
 
 
@@ -171,13 +173,15 @@ rule qc_failed_assemblies:
     output:
         os.path.join(output_dir, "qc_failed_assemblies.txt"),
     threads: 1
+    params:
+        folder=config['OUTPUT_FOLDER_NAME']
     log:
         os.path.join(output_dir_logs, "assembly_failed", "failed_assembly.out"),
     shell:
         """
-        for GENOME in results/assembly_flye/*.fasta
+        for GENOME in {params.folder}/assembly_flye/*.fasta
         do
-            HEADER=$(echo $GENOME | sed 's#_flye.fasta##g;s#results/assembly_flye/##g') 
+            HEADER=$(echo $GENOME | sed 's#_flye.fasta##g;s#{params.folder}/assembly_flye/##g') 
             if [[ -s $GENOME ]]; then
                 touch {output}
             else
@@ -200,6 +204,7 @@ rule qc_checkm2:
         gather_files=lambda wildcards, input: input.gather_files,
         db=config["DATABASES"]["CHECKM2_DB"],
         extra=config["PARAMS"]["CHECKM2"],
+        folder=config['OUTPUT_FOLDER_NAME']
     resources:
         mem_mb=10000,
     log:
@@ -212,8 +217,8 @@ rule qc_checkm2:
         
         # if all assemblies are empty/failed:
         if [[ -s checkm2_temp.fasta ]]; then
-                (checkm2 predict -t {threads} {params.extra} -i results/assembly_flye --database_path {params.db} -o results/qc_checkm2) &> {log}
-                cp results/qc_checkm2/quality_report.tsv {output.report}
+                (checkm2 predict -t {threads} {params.extra} -i {params.folder}/assembly_flye --database_path {params.db} -o {params.folder}/qc_checkm2) &> {log}
+                cp {params.folder}/qc_checkm2/quality_report.tsv {output.report}
             else
                 touch {output.report}
         fi

--- a/workflow/rules/spp.smk
+++ b/workflow/rules/spp.smk
@@ -46,7 +46,7 @@ rule spp_detection_kraken2:
         extra=config["PARAMS"]["KRAKEN2"],
     threads: 8
     resources:
-        mem_mb=16000,
+        mem_mb=10000,
     output:
         report=os.path.join(output_dir, "spp_kraken2", "{sample}_clean_std.kreport"),
         spp=os.path.join(output_dir, "{sample}_spp.tsv"),

--- a/workflow/rules/spp.smk
+++ b/workflow/rules/spp.smk
@@ -19,6 +19,7 @@ checkpoint spp_assign_organism_amr:
     threads: 1
     params:
         threshold=config["REPORT"]["SPP_DETECTION_PERCENT_THRESHOLD"],
+        folder=config['OUTPUT_FOLDER_NAME']
     log:
         os.path.join(output_dir_logs, "spp_assign_organism_amr", "assign_organism.out"),
     benchmark:
@@ -29,7 +30,7 @@ checkpoint spp_assign_organism_amr:
         )
     shell:
         """
-        (python {input.script} {params.threshold}) &> {log}
+        (python {input.script} {params.threshold} {params.folder}) &> {log}
         """
 
 
@@ -94,30 +95,31 @@ rule spp_sylph_sketch:
         sketch=config["PARAMS"]["SYLPH_SKETCH"],
         profile=config["PARAMS"]["SYLPH_PROFILE"],
         tax=config["PARAMS"]["SYLPH_TAX"],
+        folder=config['OUTPUT_FOLDER_NAME']
     threads: 8
     resources:
         mem_mb=14000,
     shell:
         """
         # run sketch AND PROFILE
-        (sylph sketch -r {input.reads} -t {threads} {params.sketch} -d results/spp_sylph) &> {log.profile}
+        (sylph sketch -r {input.reads} -t {threads} {params.sketch} -d {params.folder}/spp_sylph) &> {log.profile}
 
         # check if *.sylsp files exist
-        count=$(find  results/spp_sylph/ -type f -name "*.sylsp" | wc -l)
+        count=$(find  {params.folder}/spp_sylph/ -type f -name "*.sylsp" | wc -l)
         if [[ ${{count}} -ne 0 ]]; then
 
-            (sylph profile results/spp_sylph/*.sylsp {params.db_bac} {params.db_fungi} -t {threads} {params.profile} -o results/spp_sylph/profile.tsv) &>> {log.profile}
-            cat results/spp_sylph/profile.tsv | sed 's#Sample_file.*##g;s#_cleanfilt2k.fastq.gz##g' | sort > {output.report}
+            (sylph profile {params.folder}/spp_sylph/*.sylsp {params.db_bac} {params.db_fungi} -t {threads} {params.profile} -o {params.folder}/spp_sylph/profile.tsv) &>> {log.profile}
+            cat {params.folder}/spp_sylph/profile.tsv | sed 's#Sample_file.*##g;s#_cleanfilt2k.fastq.gz##g' | sort > {output.report}
 
             # remove .sylphmpa files if they exist as cannot force overwrite
-            files=$(find  results/spp_sylph/ -type f -name "*.sylphmpa" | wc -l)
+            files=$(find  {params.folder}/spp_sylph/ -type f -name "*.sylphmpa" | wc -l)
             if [[ ${{files}} -ne 0 ]]; then
-                rm results/spp_sylph/*.sylphmpa
+                rm {params.folder}/spp_sylph/*.sylphmpa
             fi
 
             # run taxonomy 
-            (sylph-tax taxprof results/spp_sylph/profile.tsv -t {params.tax_bac} {params.tax_fungi} -o results/spp_sylph/ {params.tax}) &> {log.tax}
-            grep "" results/spp_sylph/*sylphmpa | sed 's#:#\t##g' | sed 's/.*#SampleID.*//g' | awk 'NF' > {output.tax}
+            (sylph-tax taxprof {params.folder}/spp_sylph/profile.tsv -t {params.tax_bac} {params.tax_fungi} -o {params.folder}/spp_sylph/ {params.tax}) &> {log.tax}
+            grep "" {params.folder}/spp_sylph/*sylphmpa | sed 's#:#\t##g' | sed 's/.*#SampleID.*//g' | awk 'NF' > {output.tax}
         
         else
             (echo ""

--- a/workflow/rules/spp.smk
+++ b/workflow/rules/spp.smk
@@ -19,8 +19,8 @@ checkpoint spp_assign_organism_amr:
     threads: 1
     params:
         threshold=config["REPORT"]["SPP_DETECTION_PERCENT_THRESHOLD"],
-        folder=config['OUTPUT_FOLDER_NAME'],
-        samplelist=config['SAMPLES']
+        folder=config["OUTPUT_FOLDER_NAME"],
+        samplelist=config["SAMPLES"],
     log:
         os.path.join(output_dir_logs, "spp_assign_organism_amr", "assign_organism.out"),
     benchmark:
@@ -96,7 +96,7 @@ rule spp_sylph_sketch:
         sketch=config["PARAMS"]["SYLPH_SKETCH"],
         profile=config["PARAMS"]["SYLPH_PROFILE"],
         tax=config["PARAMS"]["SYLPH_TAX"],
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config["OUTPUT_FOLDER_NAME"],
     threads: 8
     resources:
         mem_mb=14000,

--- a/workflow/rules/spp.smk
+++ b/workflow/rules/spp.smk
@@ -19,7 +19,8 @@ checkpoint spp_assign_organism_amr:
     threads: 1
     params:
         threshold=config["REPORT"]["SPP_DETECTION_PERCENT_THRESHOLD"],
-        folder=config['OUTPUT_FOLDER_NAME']
+        folder=config['OUTPUT_FOLDER_NAME'],
+        samplelist=config['SAMPLES']
     log:
         os.path.join(output_dir_logs, "spp_assign_organism_amr", "assign_organism.out"),
     benchmark:
@@ -30,7 +31,7 @@ checkpoint spp_assign_organism_amr:
         )
     shell:
         """
-        (python {input.script} {params.threshold} {params.folder}) &> {log}
+        (python {input.script} {params.threshold} {params.folder} {params.samplelist}) &> {log}
         """
 
 

--- a/workflow/rules/typing.smk
+++ b/workflow/rules/typing.smk
@@ -52,7 +52,7 @@ rule typing_concatenate_abricate_staph_toxins:
         os.path.join(output_dir_logs, "typing_staph_aureus", "abricate_vfdb.out"),
     shell:
         """
-        if [ ! -z {params.gather_files} ]; then
+        if [ ! -z "{params.gather_files}" ]; then
             (cat {params.gather_files} | sed 's/#FILE.*//g' | awk 'NF' > {output}) &> {log}
         else
             touch {output}
@@ -97,7 +97,7 @@ rule typing_concatenate_emmtyper_strep_pyo:
         os.path.join(output_dir_logs, "typing_strep_pyo", "emmtyper.out"),
     shell:
         """
-        if [ ! -z {params.gather_files} ]; then
+        if [ ! -z "{params.gather_files}" ]; then
             (cat {params.gather_files} > {output}) &> {log}
         else
             touch {output}

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -43,8 +43,6 @@ properties:
         type: string
       KMERRESISTANCE: 
         type: string
-      QUAST: 
-        type: string
       STAPH_AUREUS_TYPING:
         type: string
       STREP_PYOGENES_TYPING:
@@ -64,7 +62,6 @@ properties:
       - COVERM
       - STARAMR
       - KMERRESISTANCE
-      - QUAST
       - STAPH_AUREUS_TYPING
       - STREP_PYOGENES_TYPING
 

--- a/workflow/scripts/00_report.Rmd
+++ b/workflow/scripts/00_report.Rmd
@@ -40,6 +40,7 @@ params:
   checkm: "x"
   vfdb: "x"
   emm: "x"
+  fungi: "x"
   cgekey: "x"
 ---
 

--- a/workflow/scripts/01_summary.Rmd
+++ b/workflow/scripts/01_summary.Rmd
@@ -50,7 +50,7 @@ library(tibble)
 
 # SUMMARY RESULTS {-}
 
-**Run name:** `r params$name`  
+**Run name:** `r params$runname`  
 
 **Time point:** `r params$hour`  
 

--- a/workflow/scripts/01_summary.Rmd
+++ b/workflow/scripts/01_summary.Rmd
@@ -124,12 +124,13 @@ if(length(missing) > 0){
 
     # add in NCBI genome size to sample list and CLSI tables
     tab <- spp_combined %>%
-      filter(level == "species") %>% 
-      mutate(genus = str_remove(organism, " .*")) %>% 
-      select(sample, genus, species = organism) %>%
+      filter(level != "order") %>%
+      pivot_wider(id_cols = c(sample), names_from = "level", values_from = "organism") %>%
       left_join(ncbi, by = "genus") %>%
       group_by(sample) %>% 
-      summarise(organism = toString(species), genome_size = round(sum(mean_size_bp/1000000), digits = 1)) %>% 
+      summarise(organism = ifelse(is.na(species), toString(genus), toString(species)), 
+                genome_size = round(sum(mean_size_bp/1000000), 
+                digits = 1)) %>% 
       ungroup() %>%
       mutate(poly = ifelse(str_detect(organism, ","), "yes", ifelse(organism == "NA", NA, "no"))) %>% 
       left_join(spp_clsi, by = "sample") %>% 

--- a/workflow/scripts/02_read_metrics.Rmd
+++ b/workflow/scripts/02_read_metrics.Rmd
@@ -145,7 +145,7 @@ if(length(missing) > 0){
 # import read metrics 
 read <- read_tsv(here(params$readsfilt), col_types = "cciiiiiiidd") %>% 
   filter(filtering == "1k") %>%
-  mutate(sample = str_remove(sample, "results/")) %>%
+  mutate(sample = str_remove(sample, ".*/")) %>%
   select(sample, `Total bases` = bases, `Number of reads` = reads, `Mean read length` = mean_length, `Read length N50` = n50, `Mean read quality` = mean_quality, `Median read length` = median_length, `Median read quality` = median_quality) %>%
   arrange(sample) 
 

--- a/workflow/scripts/02_read_metrics.Rmd
+++ b/workflow/scripts/02_read_metrics.Rmd
@@ -97,35 +97,28 @@ if(length(missing) > 0){
     spp <- bind_rows(spp_list) %>% 
       filter(sample %in% missing) %>%
       select(sample, level, org, proportion, count) %>%
-      filter(level == "S") %>%
-      mutate(level = ifelse(level == "S", "species", "unclassified")) %>%
-      filter((proportion > as.integer(params$sppproportion)) & (count > as.integer(params$minreadnumqc))) %>%
-      mutate(genus = gsub(" .*$", "", org)) %>% 
-      select(sample, species = org, genus) 
+      mutate(level = as.character(ifelse(level == "O", "order", ifelse(level == "S", "species", ifelse(level == "G", "genus", "unclassified"))))) %>%
+      filter(proportion > as.integer(params$sppproportion) & count > as.integer(params$minreadnumqc)) 
 
-    # combine kraken2 with sylph and assign genome size
-    if (nrow(spp) == 0){
-      tab <- samples %>% 
-        left_join(sylph, by = "sample") %>% 
-        left_join(ncbi, by = "genus") %>%
-        group_by(sample) %>% 
-        summarise(organism = toString(species), genome_size = round(sum(mean_size_bp/1000000), digits = 1)) %>% 
-        ungroup() %>%
-        mutate(poly = ifelse(str_detect(organism, ","), "yes", ifelse(organism == "NA", NA, "no")))     
-    } else {
+    # combine kraken2 with sylph  
+    spp_combined <- samples %>% 
+      left_join(sylph, by = "sample") %>% 
+      pivot_longer(!c("sample", "sequence_abundance"), names_to = "level", values_to = "organism") %>%
+      left_join(spp, by = c("sample", "level")) %>%
+      mutate(organism = ifelse(is.na(organism), org, organism))
+    
+    # add in NCBI genome size to sample list
+    tab <- spp_combined %>%
+    filter(level != "order") %>%
+    pivot_wider(id_cols = c(sample), names_from = "level", values_from = "organism") %>%
+    left_join(ncbi, by = "genus") %>%
+    group_by(sample) %>% 
+    summarise(organism = ifelse(is.na(species), toString(genus), toString(species)), 
+              genome_size = round(sum(mean_size_bp/1000000), 
+              digits = 1)) %>% 
+    ungroup() %>%
+    mutate(poly = ifelse(str_detect(organism, ","), "yes", ifelse(organism == "NA", NA, "no")))
 
-      tab <- samples %>% 
-        left_join(sylph, by = "sample") %>% 
-        left_join(spp, by = c("sample")) %>%
-        mutate(genus = ifelse(is.na(genus.x), genus.y, genus.x)) %>%
-        mutate(species = ifelse(is.na(species.x), species.y, species.x)) %>%
-        select(sample, genus, species) %>%
-        left_join(ncbi, by = "genus") %>%
-        group_by(sample) %>% 
-        summarise(organism = toString(species), genome_size = round(sum(mean_size_bp/1000000), digits = 1)) %>% 
-        ungroup() %>%
-        mutate(poly = ifelse(str_detect(organism, ","), "yes", ifelse(organism == "NA", NA, "no")))     
-    }  
   }
 
 } else {

--- a/workflow/scripts/03_spp.Rmd
+++ b/workflow/scripts/03_spp.Rmd
@@ -56,7 +56,7 @@ sylph <- import_sylph_tax(here(params$sylph)) %>%
 # import read twokb file to plot number of reads used for species ID
 read <- read_tsv(here(params$readsfilt), col_types = "cci") %>%
   filter(filtering == "2k") %>%
-  mutate(sample = str_remove(sample, "results/")) %>%
+  mutate(sample = str_remove(sample, ".*/")) %>%
   select(sample, `Total bases` = bases, `Number of reads` = reads)
 
 samples_for_sppID <- read %>%

--- a/workflow/scripts/04_amr.Rmd
+++ b/workflow/scripts/04_amr.Rmd
@@ -24,6 +24,7 @@ params:
   amrfinder: "x"
   kmer: "x"
   cgekey: "x"
+  fungi: "x"
 ---
 
 ```{r setup_amr, include=FALSE}
@@ -41,6 +42,8 @@ library(tibble)
 
 failed <- read_tsv(here(params$fail), col_names = "sample", col_types = "c")
 failed_samples <- failed %>% pull(sample)
+
+fungi <- import_fungi_list(params$fungi)
 
 ```
 
@@ -79,7 +82,8 @@ if(file.size(here(params$staramr)) == 0){
     mutate(`Percent identity (%)` = color_code_gene_percentage(`Percent identity (%)`, 98)) %>%
     mutate(`Percent coverage (%)` = color_code_gene_percentage(`Percent coverage (%)`, 90)) %>%
     mutate(Gene = ifelse(is.na(Gene), "None", Gene)) %>% 
-    mutate(Gene = ifelse(Gene != "None" & !is.na(Gene), cell_spec(Gene, "html", bold = TRUE), cell_spec(Gene, "html"))) 
+    mutate(Gene = ifelse(Gene != "None" & !is.na(Gene), cell_spec(Gene, "html", bold = TRUE), cell_spec(Gene, "html"))) %>%
+    filter(!((Sample %in% fungi) & Gene == "None"))
     
   # add footnotes
   names(df3)[4] <- paste0(names(df3)[4], footnote_marker_symbol(1))

--- a/workflow/scripts/assign_organism_amr.py
+++ b/workflow/scripts/assign_organism_amr.py
@@ -10,11 +10,11 @@
 #
 # COMMAND LINE USAGE:
 #
-# assign_organism_amr.py [species detection threshold integer]
+# assign_organism_amr.py [species detection threshold integer] [output folder name] [path to sample list]
 #
 # EXAMPLE:
 #
-# assign_organism_amr.py 2
+# assign_organism_amr.py 2 results/ config/samples.tsv
 #
 # = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =
 
@@ -32,6 +32,7 @@ import getopt
 # Import sppproportion param, sequence abundances below this percent will be filtered out
 sppproportion = int(sys.argv[1])
 output_folder = str(sys.argv[2])
+sample_list = str(sys.argv[3])
 
 # import sample_spp.tsv files and skip empty files
 files = glob.glob(os.path.join(output_folder, "spp_sylph_profile.tsv"))
@@ -54,6 +55,10 @@ if not data:
 
 # concat all sample_spp.tsv   
 combined_file = pd.concat(data)
+
+# get list of all samples 
+sample_list = pd.read_csv(sample_list, sep="\t", header=0)
+samples = sample_list.loc[:,('sample')]
 
 # select columns and filter for spp proportion 
 subset = combined_file[[0,3,14]]
@@ -79,8 +84,11 @@ qq["pointfinder_organism"]=q["spp_ID"].apply(lambda x: stardict.get(x))
 q_nodup = qq.drop_duplicates()
 collapsed = q_nodup.groupby("sample").first().reset_index()
 
+# join to sample list 
+all_samples_collapsed = pd.merge(samples, collapsed, on="sample", how = "left")
+
 # output assigned species
-collapsed.to_csv(os.path.join(output_folder, "spp_assigned.tsv"), sep="\t", index=False)
+all_samples_collapsed.to_csv(os.path.join(output_folder, "spp_assigned.tsv"), sep="\t", index=False)
 
 # print fungi samples to separate file
 fungi = ['Nakaseomyces glabratus', 'Candida albicans', 'Candida auris', 'Candida parapsilosis', 'Candida orthopsilosis']

--- a/workflow/scripts/assign_organism_amr.py
+++ b/workflow/scripts/assign_organism_amr.py
@@ -31,9 +31,10 @@ import getopt
 
 # Import sppproportion param, sequence abundances below this percent will be filtered out
 sppproportion = int(sys.argv[1])
+output_folder = str(sys.argv[2])
 
 # import sample_spp.tsv files and skip empty files
-files = glob.glob(os.path.join("results", "spp_sylph_profile.tsv"))
+files = glob.glob(os.path.join(output_folder, "spp_sylph_profile.tsv"))
 data = []
 
 for i in range(0,len(files)):
@@ -45,11 +46,11 @@ for i in range(0,len(files)):
 
 # if there is no data in any spp files, generate blank files and quit
 if not data:
-    with open(os.path.join("results", "spp_assigned.tsv"), mode='w') as empty:
+    with open(os.path.join(output_folder, "spp_assigned.tsv"), mode='w') as empty:
         pass
-    with open(os.path.join("results", "spp_fungi_samples.tsv"), mode='w') as empty:
+    with open(os.path.join(output_folder, "spp_fungi_samples.tsv"), mode='w') as empty:
         pass
-    with open(os.path.join("results", "spp_staph_samples.tsv"), mode='w') as empty:
+    with open(os.path.join(output_folder, "spp_staph_samples.tsv"), mode='w') as empty:
         pass
     sys.exit(0)
 
@@ -63,7 +64,7 @@ q = subset_filt[[0,14]]
 
 # trim strings in Sylph output to get only species name
 q.columns = ['sample','spp_ID']
-q.loc[:, ('sample')] = q['sample'].str.replace(r'results.qc_reads.', '', regex=True)
+q.loc[:, ('sample')] = q['sample'].str.replace(r'.*.qc_reads.', '', regex=True)
 q.loc[:, ('spp_ID')] = q['spp_ID'].str.replace(r'^\S+\.. | str.*$|_.$|MAG: |\[|\]|uncultured ', '', regex=True)
 q.loc[:, ('spp_ID')] = q['spp_ID'].str.replace(r'^(\S+\s\S+)\s.*', r'\1', regex=True)
 
@@ -81,9 +82,9 @@ q_nodup = qq.drop_duplicates()
 collapsed = q_nodup.groupby("sample").first().reset_index()
 
 # output assigned species
-collapsed.to_csv(os.path.join("results", "spp_assigned.tsv"), sep="\t", index=False)
+collapsed.to_csv(os.path.join(output_folder, "spp_assigned.tsv"), sep="\t", index=False)
 
 # print fungi samples to separate file
 fungi = ['Nakaseomyces glabratus', 'Candida albicans', 'Candida auris', 'Candida parapsilosis', 'Candida orthopsilosis']
 fungi_df = qq[qq['spp_ID'].isin(fungi)]
-fungi_df.to_csv(os.path.join("results", "spp_fungi_samples.tsv"), sep="\t", index=False)
+fungi_df.to_csv(os.path.join(output_folder, "spp_fungi_samples.tsv"), sep="\t", index=False)

--- a/workflow/scripts/assign_organism_amr.py
+++ b/workflow/scripts/assign_organism_amr.py
@@ -50,8 +50,6 @@ if not data:
         pass
     with open(os.path.join(output_folder, "spp_fungi_samples.tsv"), mode='w') as empty:
         pass
-    with open(os.path.join(output_folder, "spp_staph_samples.tsv"), mode='w') as empty:
-        pass
     sys.exit(0)
 
 # concat all sample_spp.tsv   

--- a/workflow/scripts/functions.R
+++ b/workflow/scripts/functions.R
@@ -46,7 +46,7 @@ import_sylph_tax <- function(x) {
   filter(!str_detect(clade_name, "t__")) %>% 
   separate_wider_delim(clade_name, delim = "|", names = c("domain", "phyla", "class", "order", "family", "genus", "species")) %>%
   select(sample, order, genus, species, sequence_abundance) %>%
-  mutate(sample = str_remove_all(sample, "results/spp_sylph/|_cleanfilt2k.fastq.gz.sylphmpa"),
+  mutate(sample = str_remove_all(sample, ".*/spp_sylph/|_cleanfilt2k.fastq.gz.sylphmpa"),
           species = str_remove(species, "s__"),
           order = str_remove(order, "o__"),
           genus = str_remove(genus, "g__"),
@@ -83,7 +83,7 @@ import_kraken2_tax <- function(x) {
 import_read_metrics <- function(x) {
   read_tsv(here(params$reads), col_types = "ccd", col_names = c("sample", "metric", "value")) %>% 
   select(sample, metric, value) %>% 
-  mutate(sample = str_remove(sample, "results/")) %>%
+  mutate(sample = str_remove(sample, ".*/")) %>%
   pivot_wider(id_cols = sample, names_from = metric, values_from = value) 
 }
 

--- a/workflow/scripts/functions.R
+++ b/workflow/scripts/functions.R
@@ -81,7 +81,7 @@ import_kraken2_tax <- function(x) {
 #   Tibble with read quality data
 # = = = = = = = = = = = = = = = = =
 import_read_metrics <- function(x) {
-  read_tsv(here(params$reads), col_types = "ccd", col_names = c("sample", "metric", "value")) %>% 
+  read_tsv(here(x), col_types = "ccd", col_names = c("sample", "metric", "value")) %>% 
   select(sample, metric, value) %>% 
   mutate(sample = str_remove(sample, ".*/")) %>%
   pivot_wider(id_cols = sample, names_from = metric, values_from = value) 

--- a/workflow/scripts/functions.R
+++ b/workflow/scripts/functions.R
@@ -15,6 +15,22 @@ import_sample_names <- function(x) {
 
 # = = = = = = = = = = = = = = = = =
 # PURPOSE: 
+#   Import list of fungi sample names 
+#
+# INPUT: 
+#   Path to spp_fungi_samples.tsv
+#
+# RETURN: 
+#   Vector of sample names
+# = = = = = = = = = = = = = = = = =
+
+import_fungi_list <- function(x) {
+  read_tsv(here(x)) %>%
+  pull(sample)
+}
+
+# = = = = = = = = = = = = = = = = =
+# PURPOSE: 
 #   Get list of missing/failed samples with no species ID
 #
 # INPUT: 


### PR DESCRIPTION
## v0.1.1 (2025-04-17)

### Fixed:
- Allow for custom output folder name for results
- Allow for sample to have assembly but no species ID from sylph
- Broken run name in report header
- Parsing input string of concatenate rules for typing rules
- Removed leftover parameters and outputs that were no longer used

### Changed:
- Memory requirements for kraken2 changed from 16 Gb in rule to 10 Gb
- Parsing of kraken2 species ID when sylph is missing ID in report