### PR TITLE
v0.1.2 (2025-08-18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # CHANGELOG
 
+## v0.1.2 (August 2025)
+
+### Fixed:
+
+- Antibiotics in Table1H-2 *Streptococcus* VGS now correct based on CLSI ED35:2025
+- Remove individual drugs that were present in combos from CLSI Table1s
+- Include correct genome size in report when multiple spp are present and missing samples exist
+
+### Changed:
+
+- Update default resourves for Flye, Sylph, CheckM2
+- Kraken2 filtered reports now output into subfolder `spp_kraken2`
+- NanoPlot now outputs correctly-formatted TSV file
+
+### Added: 
+
+- Add *Streptococcus infantis* to CLSI key
+- Output concatenated Kraken2 file into output directory
+
 ## v0.1.1 (April 2025)
 
 ### Fixed:

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ By default, several resource-intensive steps have a minimum resource usage alloc
 
 | Tool | CPUs | Memory |
 | :--- | :--- | :--- |
-| `sylph` | 8 | 14 Gb |
+| `sylph` | 8 | 16 Gb |
 | `kraken2` | 8 | 10 Gb |
-| `CheckM2` | 8 | 12 Gb |
-| `Flye` | 8 | 2 Gb |
+| `CheckM2` | 8 | 14 Gb |
+| `Flye` | 8 | 8 Gb |
  
 These can be overriden during the pipeline command following Snakemake usual syntax (`--set-resources`, `--set-threads`,`--set-default-resources`, etc.) or by [including a custom profile](https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles). Note that `sylph` and `kraken2` load the entire database into memory (14 Gb and 8 Gb respectively), and run time will decrease the more cores are used if running multiple samples. 
 

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -9,7 +9,7 @@ PARAMS:
     NANOQ_SPP: "-l 2000 -q 10"
     NANOQ_ASSEMBLY: "-l 1000 -q 10"
     NANOPLOTFORMAT: "--fastq"
-    NANOPLOT: "--loglength --no_static"
+    NANOPLOT: "--loglength --no_static --tsv_stats"
     KRAKEN2: "--use-names"
     SYLPH_SKETCH: "-c 200"
     SYLPH_PROFILE: "-u"

--- a/resources/Table1A-1_enterobacterales.tsv
+++ b/resources/Table1A-1_enterobacterales.tsv
@@ -19,6 +19,3 @@ amikacin
 cefotetan
 cefoxitin
 tetracycline
-trimethoprim
-sulfamethoxazole
-piperacillin

--- a/resources/Table1A-2_salmonella_shigella.tsv
+++ b/resources/Table1A-2_salmonella_shigella.tsv
@@ -5,5 +5,3 @@ trimethoprim-sulfamethoxazole
 cefotaxime
 ceftriaxone
 azithromycin
-trimethoprim
-sulfamethoxazole

--- a/resources/Table1B-2_acinetobacter.tsv
+++ b/resources/Table1B-2_acinetobacter.tsv
@@ -10,7 +10,3 @@ amikacin
 piperacillin-tazobactam
 trimethoprim-sulfamethoxazole
 minocycline
-piperacillin
-tazobactam
-trimethoprim
-sulfamethoxazole

--- a/resources/Table1B-5_non-enterobacterales.tsv
+++ b/resources/Table1B-5_non-enterobacterales.tsv
@@ -11,6 +11,3 @@ aztreonam
 ciprofloxacin
 levofloxacin
 minocycline
-piperacillin
-trimethoprim
-sulfamethoxazole

--- a/resources/Table1C_staphylococcus.tsv
+++ b/resources/Table1C_staphylococcus.tsv
@@ -12,5 +12,3 @@ vancomycin
 penicillin
 daptomycin
 linezolid
-trimethoprim
-sulfamethoxazole

--- a/resources/Table1E_haemophilus_influenzae.tsv
+++ b/resources/Table1E_haemophilus_influenzae.tsv
@@ -8,5 +8,3 @@ ciprofloxacin
 levofloxacin
 moxifloxacin
 trimethoprim-sulfamethoxazole
-trimethoprim
-sulfamethoxazole

--- a/resources/Table1G_streptococcus_pneumoniae.tsv
+++ b/resources/Table1G_streptococcus_pneumoniae.tsv
@@ -10,5 +10,3 @@ tetracycline
 levofloxacin
 moxifloxacin
 vancomycin
-trimethoprim
-sulfamethoxazole

--- a/resources/Table1H-2_streptococcus_VGS.tsv
+++ b/resources/Table1H-2_streptococcus_VGS.tsv
@@ -1,5 +1,5 @@
-clindamycin
-erythromycin
-penicillin
 ampicillin
-tetracycline
+penicillin
+cefotaxime
+ceftriaxone
+vancomycin

--- a/resources/clsi_key.txt
+++ b/resources/clsi_key.txt
@@ -28,6 +28,7 @@ species	Streptococcus anginosus	streptococcus_VGS
 species	Streptococcus intermedius	streptococcus_VGS
 species	Streptococcus salivarius	streptococcus_VGS
 species	Streptococcus mitis	streptococcus_VGS
+species	Streptococcus infantis	streptococcus_VGS
 species	Streptococcus sanguinis	streptococcus_VGS
 species	Streptococcus bovis	streptococcus_VGS
 species	Streptococcus vestibularis	streptococcus_VGS

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -123,9 +123,7 @@ rule generate_report:
         "envs/r_env_report.yml"
     input:
         rmd=os.path.join("workflow", "scripts", "00_report.Rmd"),
-        spp=expand(
-            os.path.join(output_dir, "{sample}_spp.tsv"), sample=samples["sample"]
-        ),
+        spp=os.path.join(output_dir, "spp_kraken2_classification.tsv"),
         sylph=os.path.join(output_dir, "spp_sylph_taxonomy.tsv"),
         reads=os.path.join(output_dir, "qc_read_metrics_clean.tsv"),
         readsfilt=os.path.join(output_dir, "qc_read_metrics_cleanfilt.tsv"),

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -17,7 +17,8 @@ checkpoint assembly_flye:
         folder=config["OUTPUT_FOLDER_NAME"],
     threads: 8
     resources:
-        mem_mb=2000,
+        mem_mb=8000,
+        runtime='180m',
     log:
         os.path.join(output_dir_logs, "assembly_flye", "{sample}_flye.out"),
     benchmark:

--- a/workflow/rules/assembly.smk
+++ b/workflow/rules/assembly.smk
@@ -18,7 +18,7 @@ checkpoint assembly_flye:
     threads: 8
     resources:
         mem_mb=8000,
-        runtime='180m',
+        runtime="180m",
     log:
         os.path.join(output_dir_logs, "assembly_flye", "{sample}_flye.out"),
     benchmark:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -150,8 +150,8 @@ rule qc_read_metrics:
     shell:
         """
         # for cleaned reads
-        (grep -H "Mean read\\|Median read\\|Number of reads\\|N50\\|Total bases" {input.cleanreports} | tr -s '[:blank:]' |  sed 's#:#\t#g;s#_clean/NanoStats.txt##g;s#qc_nanoplot/##g;s#,##g'  > {output.clean}) &> {log}
-
+        (grep -H "mean_\\|median_\\|number_of_reads\\|n50\\|number_of_bases" {input.cleanreports} | tr -s '[:blank:]' |  sed 's#:#\t#g;s#_clean/NanoStats.txt##g;s#qc_nanoplot/##g;s#,##g'  > {output.clean}) &> {log}
+        
         # for 1kb reads
         cat {input.onekbreports} {input.twokbreports}  > filt_temp.txt
         if [[ -s filt_temp.txt ]]; then

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -206,7 +206,8 @@ rule qc_checkm2:
         extra=config["PARAMS"]["CHECKM2"],
         folder=config["OUTPUT_FOLDER_NAME"],
     resources:
-        mem_mb=10000,
+        mem_mb=14000,
+        runtime='180m',
     log:
         os.path.join(output_dir_logs, "qc_checkm2", "checkm2.out"),
     benchmark:

--- a/workflow/rules/qc.smk
+++ b/workflow/rules/qc.smk
@@ -207,7 +207,7 @@ rule qc_checkm2:
         folder=config["OUTPUT_FOLDER_NAME"],
     resources:
         mem_mb=14000,
-        runtime='180m',
+        runtime="180m",
     log:
         os.path.join(output_dir_logs, "qc_checkm2", "checkm2.out"),
     benchmark:

--- a/workflow/rules/spp.smk
+++ b/workflow/rules/spp.smk
@@ -4,6 +4,7 @@
 #
 ####################################
 
+localrules: spp_kraken2_concatenate
 
 # based on output from Sylph, get list of species-specific database parameters for AMR detection
 checkpoint spp_assign_organism_amr:
@@ -50,7 +51,7 @@ rule spp_detection_kraken2:
         mem_mb=10000,
     output:
         report=os.path.join(output_dir, "spp_kraken2", "{sample}_clean_std.kreport"),
-        spp=os.path.join(output_dir, "{sample}_spp.tsv"),
+        spp=os.path.join(output_dir, "spp_kraken2", "{sample}_spp.tsv"),
     log:
         os.path.join(output_dir_logs, "spp_kraken2", "{sample}_kraken2.out"),
     benchmark:
@@ -70,6 +71,19 @@ rule spp_detection_kraken2:
             {output.report} | tr -s '[:blank:]' | sed 's#_std.kreport:##g;s#\\t #\\t#g' > {output.spp}) &> {log}
         """
 
+# concatenate output of rule spp_detection_kraken2 for all samples 
+rule spp_kraken2_concatenate:
+    input:
+        report=expand(os.path.join(output_dir, "spp_kraken2", "{sample}_spp.tsv"), sample = samples["sample"])
+    output:
+        os.path.join(output_dir, "spp_kraken2_classification.tsv")
+    threads: 1
+    log:
+        os.path.join(output_dir_logs, "spp_kraken2_concatenate", "kraken2_concatenate.out")
+    shell:
+        """
+        cat {input.report} > {output}
+        """
 
 # detect species using Sylph
 rule spp_sylph_sketch:

--- a/workflow/rules/spp.smk
+++ b/workflow/rules/spp.smk
@@ -4,7 +4,10 @@
 #
 ####################################
 
-localrules: spp_kraken2_concatenate
+
+localrules:
+    spp_kraken2_concatenate,
+
 
 # based on output from Sylph, get list of species-specific database parameters for AMR detection
 checkpoint spp_assign_organism_amr:
@@ -71,19 +74,26 @@ rule spp_detection_kraken2:
             {output.report} | tr -s '[:blank:]' | sed 's#_std.kreport:##g;s#\\t #\\t#g' > {output.spp}) &> {log}
         """
 
-# concatenate output of rule spp_detection_kraken2 for all samples 
+
+# concatenate output of rule spp_detection_kraken2 for all samples
 rule spp_kraken2_concatenate:
     input:
-        report=expand(os.path.join(output_dir, "spp_kraken2", "{sample}_spp.tsv"), sample = samples["sample"])
+        report=expand(
+            os.path.join(output_dir, "spp_kraken2", "{sample}_spp.tsv"),
+            sample=samples["sample"],
+        ),
     output:
-        os.path.join(output_dir, "spp_kraken2_classification.tsv")
+        os.path.join(output_dir, "spp_kraken2_classification.tsv"),
     threads: 1
     log:
-        os.path.join(output_dir_logs, "spp_kraken2_concatenate", "kraken2_concatenate.out")
+        os.path.join(
+            output_dir_logs, "spp_kraken2_concatenate", "kraken2_concatenate.out"
+        ),
     shell:
         """
         cat {input.report} > {output}
         """
+
 
 # detect species using Sylph
 rule spp_sylph_sketch:

--- a/workflow/rules/spp.smk
+++ b/workflow/rules/spp.smk
@@ -99,7 +99,7 @@ rule spp_sylph_sketch:
         folder=config["OUTPUT_FOLDER_NAME"],
     threads: 8
     resources:
-        mem_mb=14000,
+        mem_mb=16000,
     shell:
         """
         # run sketch AND PROFILE

--- a/workflow/scripts/01_summary.Rmd
+++ b/workflow/scripts/01_summary.Rmd
@@ -125,10 +125,11 @@ if(length(missing) > 0){
     # add in NCBI genome size to sample list and CLSI tables
     tab <- spp_combined %>%
       filter(level != "order") %>%
-      pivot_wider(id_cols = c(sample), names_from = "level", values_from = "organism") %>%
+      pivot_wider(id_cols = c(sample), names_from = "level", values_from = "organism", values_fn = function(x) toString(x)) %>%
+      separate_longer_delim(cols = c("genus", "species"), delim = ", ") %>%
       left_join(ncbi, by = "genus") %>%
       group_by(sample) %>% 
-      summarise(organism = ifelse(is.na(species), toString(genus), toString(species)), 
+      summarise(organism = ifelse(is.na(toString(species)), toString(genus), toString(species)), 
                 genome_size = round(sum(mean_size_bp/1000000), 
                 digits = 1)) %>% 
       ungroup() %>%

--- a/workflow/scripts/01_summary.Rmd
+++ b/workflow/scripts/01_summary.Rmd
@@ -256,7 +256,7 @@ read <- import_read_metrics(here(params$reads))
 
 # assign qc pass/fail based on species ID, median read length, median read quality
 all_qc <- left_join(all, read, by = "sample") %>% 
-  mutate(qc = ifelse((!is.na(organism) & organism != "NA" & !str_detect(organism, "\\*")) & `Median read length` > as.integer(params$minreadlength) &  `Median read quality` > as.integer(params$minreadqscore) & `Number of reads` > as.integer(params$minreadnumqc), "pass", "fail"))  %>%
+  mutate(qc = ifelse((!is.na(organism) & organism != "NA" & !str_detect(organism, "\\*")) & median_read_length > as.integer(params$minreadlength) &  median_qual > as.integer(params$minreadqscore) & number_of_reads > as.integer(params$minreadnumqc), "pass", "fail"))  %>%
   select(Sample = sample, Organism = organism, `Polymicrobial` = poly, `QC` = qc, `Predicted resistance phenotype` = cge_phenotype) %>% 
   mutate(`QC` = ifelse(`QC` == "fail", cell_spec(`QC`, "html", color = "#F8766D", bold = TRUE), cell_spec(`QC`, "html", color = "#00BFC4", bold = TRUE))) %>% 
   mutate(`Predicted resistance phenotype` = ifelse(`Predicted resistance phenotype` == "NA" | is.na(`Predicted resistance phenotype`), "Could not predict", `Predicted resistance phenotype`)) 

--- a/workflow/scripts/01_summary.Rmd
+++ b/workflow/scripts/01_summary.Rmd
@@ -77,20 +77,10 @@ missing <- get_missing_samples(samples, sylph)  # these samples selected for kra
 if(length(missing) > 0){
 
   # import kraken2 data
-  spp_list <- list()
-  spp_files <- strsplit(params$spp, "\\s+")[[1]]
-
-  for (i in 1:length(spp_files)) {
-      if(file.size(here(spp_files[i])) == 0){
-        next
-      
-        } else {
-          spp_list[[i]] <- import_kraken2_tax(here(spp_files[i]))
-        }
-  }
+  spp_list <- import_kraken2_tax(here(params$spp))
 
   # create an empty file if no samples have any organism assigned
-  if(nrow(bind_rows(spp_list)) == 0){
+  if(nrow(spp_list) == 0){
     tab <- samples %>% 
     add_column(organism = NA, 
             poly = NA, 
@@ -100,7 +90,7 @@ if(length(missing) > 0){
 
   } else {
     # combine into one file and filter for those that are missing
-    spp <- bind_rows(spp_list) %>% 
+    spp <- spp_list %>% 
       filter(sample %in% missing) %>%
       select(sample, level, org, proportion, count) %>%
       mutate(level = as.character(ifelse(level == "O", "order", ifelse(level == "S", "species", ifelse(level == "G", "genus", "unclassified"))))) %>%

--- a/workflow/scripts/02_read_metrics.Rmd
+++ b/workflow/scripts/02_read_metrics.Rmd
@@ -110,10 +110,11 @@ if(length(missing) > 0){
     # add in NCBI genome size to sample list
     tab <- spp_combined %>%
     filter(level != "order") %>%
-    pivot_wider(id_cols = c(sample), names_from = "level", values_from = "organism") %>%
+    pivot_wider(id_cols = c(sample), names_from = "level", values_from = "organism", values_fn = function(x) toString(x)) %>%
+    separate_longer_delim(cols = c("genus", "species"), delim = ", ") %>%
     left_join(ncbi, by = "genus") %>%
     group_by(sample) %>% 
-    summarise(organism = ifelse(is.na(species), toString(genus), toString(species)), 
+    summarise(organism = ifelse(is.na(toString(species)), toString(genus), toString(species)), 
               genome_size = round(sum(mean_size_bp/1000000), 
               digits = 1)) %>% 
     ungroup() %>%

--- a/workflow/scripts/02_read_metrics.Rmd
+++ b/workflow/scripts/02_read_metrics.Rmd
@@ -134,7 +134,7 @@ read <- read_tsv(here(params$readsfilt), col_types = "cciiiiiiidd") %>%
   arrange(sample) 
 
 read2 <- import_read_metrics(here(params$reads)) %>% 
-  select(sample, num_reads_pre_filter = `Number of reads`, total_bases_pre_filter = `Total bases`) 
+  select(sample, num_reads_pre_filter = number_of_reads, total_bases_pre_filter = number_of_bases) 
 
 all_reads <- left_join(read, read2, by = "sample")
 

--- a/workflow/scripts/02_read_metrics.Rmd
+++ b/workflow/scripts/02_read_metrics.Rmd
@@ -70,20 +70,10 @@ missing <- get_missing_samples(samples, sylph) # these samples selected for krak
 if(length(missing) > 0){
 
   # import kraken2 data
-  spp_list <- list()
-  spp_files <- strsplit(params$spp, "\\s+")[[1]]
-
-  for (i in 1:length(spp_files)) {
-      if(file.size(here(spp_files[i])) == 0){
-        next
-      
-        } else {
-          spp_list[[i]] <- import_kraken2_tax(here(spp_files[i]))
-        }
-  }
+  spp_list <- import_kraken2_tax(here(params$spp))
 
   # create an empty file if no samples have any organism assigned
-  if(nrow(bind_rows(spp_list)) == 0){
+  if(nrow(spp_list) == 0){
     tab <- samples %>% 
     add_column(organism = NA, 
             poly = NA, 
@@ -94,7 +84,7 @@ if(length(missing) > 0){
   } else {
     
     # combine into one file and filter for those that are missing
-    spp <- bind_rows(spp_list) %>% 
+    spp <- spp_list %>% 
       filter(sample %in% missing) %>%
       select(sample, level, org, proportion, count) %>%
       mutate(level = as.character(ifelse(level == "O", "order", ifelse(level == "S", "species", ifelse(level == "G", "genus", "unclassified"))))) %>%

--- a/workflow/scripts/03_spp.Rmd
+++ b/workflow/scripts/03_spp.Rmd
@@ -17,7 +17,6 @@ output:
     self_contained: true
     
 params:
-  reads: "x"
   readsfilt: "x"
   spp: "x"
   sylph: "x"

--- a/workflow/scripts/04_amr.Rmd
+++ b/workflow/scripts/04_amr.Rmd
@@ -18,7 +18,6 @@ output:
     self_contained: true
     
 params:
-  reads: "x"
   fail: "x"
   staramr: "x"
   amrfinder: "x"


### PR DESCRIPTION
## v0.1.2 (2025-08-18)

### Fixed:

- Antibiotics in Table1H-2 *Streptococcus* VGS now correct based on CLSI ED35:2025 (790d4ec8758f4868c551a3688028f9311cc99e9d)
- Remove individual drugs that were present in combos from CLSI Table1s (7051737602a68076f8272136efbfda8b80ee02a1)
- Include correct genome size in report when multiple spp are present and missing samples exist (19dfce445ac399ea1f223fa0d6d0fbea842dc0e3)

### Changed:

- Update default resourves for Flye, Sylph, CheckM2 (0f8506461b78a0e3d59fb1a4cf199f617f280261)
- Kraken2 filtered reports now output into subfolder `spp_kraken2` (b3c5762594a25e8f9fb34d0dd8bddb1f6550d078)
- NanoPlot now outputs correctly-formatted TSV file (ffbfccb68d3690b7a71e74794e8d444d79d01914)

### Added: 

- Add *Streptococcus infantis* to CLSI key (e898ca3453ceedf753f9871575c7e430393ec755)
- Output concatenated Kraken2 file into output directory (b3c5762594a25e8f9fb34d0dd8bddb1f6550d078)